### PR TITLE
LOG-6711: Enhancing the Observability Data Model for OVN and auditd Logs

### DIFF
--- a/cluster-logging.md
+++ b/cluster-logging.md
@@ -30,9 +30,10 @@ The "Applicable Sources" column shows which log sources this field applies to:
 
 * `all` is a field that is present on all logs
 * `container` is a field that is present on Kubernetes Container logs (both application and infrastructure)
-* `audit` is a field that is present on Kubernetes and OpenShift API and OVN Logs
+* `audit` is a field that is present on Kubernetes and OpenShift API
 * `auditd` is a field that is present on Node auditd logs
 * `journal` is a field that is present on Node journal logs
+* `ovn log` is field that is present on OVN Logs
 
 | Name |  Applicable Sources | Comment |
 | :--- | :------------------ | :------ |
@@ -104,10 +105,24 @@ The "Storage" column shows whether the attribute is stored into a LokiStack usin
 | `service.name` | resource | journal | stream label | |
 | `systemd.t.*` | log | journal | structured metadata | |
 | `systemd.u.*` | log | journal | structured metadata | |
+| `k8s.ovn.component` | resource | OVN logs | stream label | The OVN component generating the log|
+| `k8s.ovn.sequence` | log | OVN logs | structured metadata | The sequence number indicating the log entry's order|
+| `k8s.ovn.message` | log | OVN logs | structured metadata | The main content of the log entry, can containing key-value pairs|
+| `k8s.ovn.message.*` | log | OVN logs | structured metadata | Individual key-value pairs parsed from the `ovn.message` field|
+| `k8s.auditd.event.type` | log | auditd logs | structured metadata | The type of auditd event (e.g., `SYSCALL`, `PROCTITLE`) |
+| `k8s.auditd.event.*`| log | auditd logs | structured metadata | The audit event fields |
+
+
 
 **Note:** Attributes marked as "Compatibility attribute" are added to support minimal backwards compatibility with the [ViaQ](https://github.com/openshift/cluster-logging-operator/blob/release-6.0/docs/reference/datamodels/viaq/v1.adoc) data model. These attributes should be considered deprecated and will be removed one release after **General Acceptance** of Red Hat OpenShift Logging.
 
 **Note:** Loki changes the attribute names when persisting them to storage. They will be lower-cased and all characters in the set: (`.`,`/`,`-`) will be replaced by underscores (`_`). For example, `k8s.namespace.name` will become `k8s_namespace_name`.
+
+**Note:** 
+
+[Audit Record Types](https://access.redhat.com/articles/4409591#audit-record-types-2) 
+
+[Audit Event Fields](https://access.redhat.com/articles/4409591#audit-event-fields-1)
 
 ## References
 

--- a/cluster-logging.md
+++ b/cluster-logging.md
@@ -107,22 +107,19 @@ The "Storage" column shows whether the attribute is stored into a LokiStack usin
 | `systemd.u.*` | log | journal | structured metadata | |
 | `k8s.ovn.component` | resource | OVN logs | stream label | The OVN component generating the log|
 | `k8s.ovn.sequence` | log | OVN logs | structured metadata | The sequence number indicating the log entry's order|
-| `k8s.ovn.message` | log | OVN logs | structured metadata | The main content of the log entry, can containing key-value pairs|
-| `k8s.ovn.message.*` | log | OVN logs | structured metadata | Individual key-value pairs parsed from the `ovn.message` field|
-| `k8s.auditd.event.type` | log | auditd logs | structured metadata | The type of auditd event (e.g., `SYSCALL`, `PROCTITLE`) |
-| `k8s.auditd.event.*`| log | auditd logs | structured metadata | The audit event fields |
-
+| `auditd.type` | log | auditd logs | structured metadata | The type of auditd event (e.g., `SYSCALL`, `PROCTITLE`) |
+| `auditd.sequence` | log | auditd logs | structured metadata | The sequence number indicating the log entry's order will taken from msg: msg=audit(<epoch time>:<sequence number>|
 
 
 **Note:** Attributes marked as "Compatibility attribute" are added to support minimal backwards compatibility with the [ViaQ](https://github.com/openshift/cluster-logging-operator/blob/release-6.0/docs/reference/datamodels/viaq/v1.adoc) data model. These attributes should be considered deprecated and will be removed one release after **General Acceptance** of Red Hat OpenShift Logging.
 
 **Note:** Loki changes the attribute names when persisting them to storage. They will be lower-cased and all characters in the set: (`.`,`/`,`-`) will be replaced by underscores (`_`). For example, `k8s.namespace.name` will become `k8s_namespace_name`.
 
-**Note:** 
+**Note:** Auditd log event mandatory parts are `type` and `msg`, with following key-value pair fileds (e.g. `type=USER_LOGIN msg=audit(1582710609.181:104544): user=root exe="/usr/bin/sshd" hostname=192.168.1.1 res=success`)
+Event Type (type=) is kind of action was audited (e.g., USER_CMD, SYSCALL, LOGIN). [Audit Record Types](https://access.redhat.com/articles/4409591#audit-record-types-2) 
+Message (msg=) contains the audit timestamp and event sequence number: msg=audit(<epoch time>:<sequence number>)
+Commonly used fields: pid, uid, comm, exe. [Audit Event Fields](https://access.redhat.com/articles/4409591#audit-event-fields-1)
 
-[Audit Record Types](https://access.redhat.com/articles/4409591#audit-record-types-2) 
-
-[Audit Event Fields](https://access.redhat.com/articles/4409591#audit-event-fields-1)
 
 ## References
 


### PR DESCRIPTION
# Enhancing the Observability Data Model for OVN and auditd Logs
This PR proposes updates to the OTLP Semantic Conventions Table to improve support for OVN logs and auditd logs in observability pipelines. Introduce the `k8s.ovn.*` and `k8s.auditd.*` namespaces to structure key log attributes, making them easier to process and analyze in OTLP pipelines.

## OpenShift Virtual Network (OVN) logs

The OVN log format follows a structured, delimited by ` | `: 
`Timestamp|Sequence|Component|Severity|Message`
- Timestamp: The precise time the log entry was generated (often in RFC3339 or nanosecond-precision format).
- Sequence: A numerical identifier for log ordering, useful for tracing event sequences.
- Component: The OVN subsystem or module generating the log (e.g., acl_log(ovn_pinctrl0)).
- Severity: Log level (INFO, WARN, ERROR, etc.).
- Message: The actual log content, which may contain structured key-value data.


Example OVN Log (raw text format) :

`2025-02-18T15:25:51.943228982Z|00004|acl_log(ovn_pinctrl0)|INFO|name=verify-audit-logging_deny-all, verdict=drop`

#### OTLP Transformation:
```
{
  "logRecords": {
    "attributes": [
      {
        "key": "k8s.ovn.sequence",
        "value": {
          "stringValue": "00004"
        }
      },
    ],
    "body": {
      "stringValue": "name=verify-audit-logging_deny-all, verdict=drop"
    },
    "observedTimeUnixNano": "1739898407584002081",
    "timeUnixNano": "1739898407582915200",
    "severityText": "info",
  },
  "resource": {
    "attributes": [
      {
        "key": "openshift.cluster.uid",
        "value": {
          "stringValue": "functional"
        }
      },
      {
        "key": "openshift.log.source",
        "value": {
          "stringValue": "ovn"
        }
      },
      {
        "key": "openshift.log.type",
        "value": {
          "stringValue": "audit"
        }
      },
      {
        "key": "k8s.node.name",
        "value": {
          "stringValue": "ip-10-0-95-59.ec2.internal"
        }
      },
      {
        "key": "openshift.label.foo",
        "value": {
          "stringValue": "bar"
        }
      },
      {
        "key": "log_type",
        "value": {
          "stringValue": "audit"
        }
      },
      {
        "key": "log_source",
        "value": {
          "stringValue": "ovn"
        }
      },
      {
        "key": "openshift.cluster_id",
        "value": {
          "stringValue": "functional"
        }
      },
      {
        "key": "kubernetes.host",
        "value": {
          "stringValue": "ip-10-0-95-59.ec2.internal"
        }
      },
      {
        "key": "k8s.ovn.component",
        "value": {
          "stringValue": "acl_log(ovn_pinctrl0)"
        }
      }
    ]
  }
}
```
~~**Dynamic Attributes:** The `k8s.ovn.message.<key>` allows for the storage of specific details present in the log message as individual attributes, facilitating more granular querying and analysis. For instance, a log message containing `name=verify-audit-logging_deny-all, verdict=drop` would result in attributes `k8s.ovn.message.name=verify-audit-logging_deny-all` and `k8s.ovn.message.verdict=drop.`~~

#### Proposed Changes to OTLP Semantic Conventions Table
| Name | Location | Applicable Sources | Storage (LokiStack) | Comment |
| :--- | :------- | :----------------- | :------------------ | :------ |
| `k8s.ovn.component` | resource | OVN logs | stream label | The OVN component generating the log|
| `k8s.ovn.sequence` | log | OVN logs | structured metadata | The sequence number indicating the log entry's order|



## Auditd logs
Audit logs generated by `auditd` follow a structured format that consists of key-value pairs separated by spaces. These logs contain mandatory fields (present in every event) and optional fields (which depend on the event type).

#### Basic Structure of an auditd Log Entry
Mandatory fields are `type` and `msg` with following key-value pair fields.
Event Type (type=) is kind of action was audited (e.g., USER_CMD, SYSCALL, LOGIN). [Audit Record Types](https://access.redhat.com/articles/4409591#audit-record-types-2) 
Message (msg=) contains the audit timestamp and event sequence number: `msg=audit(<epoch time>:<sequence number>)`
Commonly used fields:  `pid`, `uid`, `comm`, `exe`. [Audit Event Fields](https://access.redhat.com/articles/4409591#audit-event-fields-1)

Example auditd Log (Raw Format):

`type=USER_LOGIN msg=audit(1582710609.181:104544): user=root exe="/usr/bin/sshd" hostname=192.168.1.1 res=success
`

#### OTLP Transformation:
```
{
  "logRecords": {
    "attributes": [
      {
        "key": "k8s.auditd.event.type",
        "value": {
          "stringValue": "USER_LOGIN"
        }
      },
    ],
    "body": {
      "stringValue": "type=USER_LOGIN msg=audit(1582710609.181:104544): user=root exe=\"/usr/bin/sshd\" hostname=192.168.1.1 res=success"
    },
    "observedTimeUnixNano": "1739898407584002081",
    "timeUnixNano": "1739898407582915200",
    "severityText": "info",
  },
  "resource": {
    "attributes": [
      {
        "key": "openshift.cluster.uid",
        "value": {
          "stringValue": "functional"
        }
      },
      {
        "key": "openshift.log.source",
        "value": {
          "stringValue": "ovn"
        }
      },
      {
        "key": "openshift.log.type",
        "value": {
          "stringValue": "audit"
        }
      },
      {
        "key": "k8s.node.name",
        "value": {
          "stringValue": "ip-10-0-95-59.ec2.internal"
        }
      },
      {
        "key": "openshift.label.foo",
        "value": {
          "stringValue": "bar"
        }
      },
      {
        "key": "log_type",
        "value": {
          "stringValue": "audit"
        }
      },
      {
        "key": "log_source",
        "value": {
          "stringValue": "ovn"
        }
      },
      {
        "key": "openshift.cluster_id",
        "value": {
          "stringValue": "functional"
        }
      },
      {
        "key": "kubernetes.host",
        "value": {
          "stringValue": "ip-10-0-95-59.ec2.internal"
        }
      }
    ]
  }
}
```
~~**Dynamic Attributes:** The `auditd.event.<key>` allows for the storage of specific details present in the log message as individual attributes, facilitating more granular querying and analysis. For instance, a log message containing `user=root exe="/usr/bin/sshd" hostname=192.168.1.1 res=success` would result in attributes `auditd.user=root`, `auditd.exe="/usr/bin/sshd"`, `auditd.hostname=192.168.1.1` and `auditd.res=success`~~

#### Proposed Changes to OTLP Semantic Conventions Table
| Name | Location | Applicable Sources | Storage (LokiStack) | Comment |
| :--- | :------- | :----------------- | :------------------ | :------ |
| `auditd.type` | log | auditd logs | structured metadata | The type of auditd event (e.g., `SYSCALL`, `PROCTITLE`) |
| `auditd.sequence`| log | auditd logs | structured metadata | The sequence number indicating the log entry's order |
